### PR TITLE
Use updated Fields API Option tuple syntax

### DIFF
--- a/form-customizations/fields-api-sample.php
+++ b/form-customizations/fields-api-sample.php
@@ -55,10 +55,10 @@ add_action( 'give_fields_payment_mode_before_gateways', function( $collection ) 
         // Select field with options.
         give_field( 'select', 'mySelectField' )
             ->label( 'My Select Field' )
-            ->options([
-                'aye' => __( 'Aye' ),
-                'bee' => __( 'Bee' ),
-            ])
+            ->options(
+                [ 'aye', __( 'Aye' ) ],
+                [ 'bee', __( 'Bee' ) ]
+            )
 
     );
 });


### PR DESCRIPTION
This just updates the Fields API sample snippet to use the new syntax for options. The previous associative array syntax was removed and the options method signature was changed to be variadic.
